### PR TITLE
Fix fishing score always pinned at 10/10

### DIFF
--- a/custom_components/fishing_assistant/helpers/astro.py
+++ b/custom_components/fishing_assistant/helpers/astro.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from typing import Dict
 from skyfield.api import load, wgs84
 from skyfield import almanac
@@ -7,15 +8,15 @@ from homeassistant.core import HomeAssistant
 import logging
 
 
-async def calculate_astronomy_forecast(hass: HomeAssistant, lat: float, lon: float, days: int = 7) -> Dict[str, dict]:
+async def calculate_astronomy_forecast(hass: HomeAssistant, lat: float, lon: float, tz_name: str = "UTC", days: int = 7) -> Dict[str, dict]:
     ts = load.timescale()
-    
+
     # Check if ephemeris file exists, if not create the directory
     data_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
     os.makedirs(data_dir, exist_ok=True)
-    
+
     eph_path = os.path.join(data_dir, "de421.bsp")
-    
+
     # Download if not exists
     if not os.path.exists(eph_path):
         _LOGGER = logging.getLogger(__name__)
@@ -26,18 +27,34 @@ async def calculate_astronomy_forecast(hass: HomeAssistant, lat: float, lon: flo
             url = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de421.bsp"
             urllib.request.urlretrieve(url, eph_path)
             return load(eph_path)
-            
+
         eph = await hass.async_add_executor_job(download_eph)
     else:
         # Load existing file
         eph = await hass.async_add_executor_job(lambda: load(eph_path))
     location = wgs84.latlon(lat, lon)
 
-    start_date = datetime.now(timezone.utc).date()
+    # All event times below are formatted in this local timezone so that they
+    # line up with the local-time hourly weather data used for scoring. The
+    # skyfield events themselves are computed in UTC; we convert on output.
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = timezone.utc
+
+    def local(t):
+        """skyfield Time -> local tz-aware datetime."""
+        return t.utc_datetime().astimezone(tz)
+
+    start_date = datetime.now(tz).date()
     end_date = start_date + timedelta(days=days)
 
-    t0 = ts.utc(start_date.year, start_date.month, start_date.day)
-    t1 = ts.utc(end_date.year, end_date.month, end_date.day)
+    # Search a slightly wider UTC window so events that fall on the first/last
+    # local day near midnight (up to a timezone offset away from UTC) are caught.
+    search_start = start_date - timedelta(days=1)
+    search_end = end_date + timedelta(days=1)
+    t0 = ts.utc(search_start.year, search_start.month, search_start.day)
+    t1 = ts.utc(search_end.year, search_end.month, search_end.day)
 
     # Astronomy events
     moon_phases = almanac.moon_phases(eph)
@@ -59,31 +76,34 @@ async def calculate_astronomy_forecast(hass: HomeAssistant, lat: float, lon: flo
     # Moon phase per day
     times, phases = almanac.find_discrete(t0, t1, moon_phases)
     for t, p in zip(times, phases):
-        date_str = str(t.utc_datetime().date())
+        date_str = str(local(t).date())
         events["moon_phase"][date_str] = float(round(p % 1, 3))
 
     # Moonrise / moonset
     times, events_raw = almanac.find_discrete(t0, t1, moon_rise_set)
     for t, ev in zip(times, events_raw):
-        date_str = str(t.utc_datetime().date())
+        lt = local(t)
+        date_str = str(lt.date())
         key = "moonrise" if ev == 1 else "moonset"
-        events[key][date_str] = t.utc_strftime("%H:%M")
+        events[key][date_str] = lt.strftime("%H:%M")
 
     # Transit / underfoot
     times, events_raw = almanac.find_discrete(t0, t1, moon_transits)
     for t, ev in zip(times, events_raw):
-        date_str = str(t.utc_datetime().date())
+        lt = local(t)
+        date_str = str(lt.date())
         key = "moon_transit" if ev == 1 else "moon_underfoot"
         if key not in events:
             events[key] = {}
-        events[key][date_str] = t.utc_strftime("%H:%M")
+        events[key][date_str] = lt.strftime("%H:%M")
 
     # Sunrise / sunset
     times, events_raw = almanac.find_discrete(t0, t1, sun_rise_set)
     for t, ev in zip(times, events_raw):
-        date_str = str(t.utc_datetime().date())
+        lt = local(t)
+        date_str = str(lt.date())
         key = "sunrise" if ev == 1 else "sunset"
-        events[key][date_str] = t.utc_strftime("%H:%M")
+        events[key][date_str] = lt.strftime("%H:%M")
 
     # Final forecast
     forecast = {}

--- a/custom_components/fishing_assistant/score.py
+++ b/custom_components/fishing_assistant/score.py
@@ -84,7 +84,7 @@ async def get_fish_score_forecast(
     end_date = today + datetime.timedelta(days=6)
 
     # Get moon + sun event timings from Skyfield
-    astro_data = await calculate_astronomy_forecast(hass, lat, lon, days=7)
+    astro_data = await calculate_astronomy_forecast(hass, lat, lon, timezone, days=7)
 
     if not astro_data:
         return {}

--- a/custom_components/fishing_assistant/score.py
+++ b/custom_components/fishing_assistant/score.py
@@ -14,7 +14,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def scale_score(score):
-    stretched = (score - 0.5) / (0.9 - 0.5) * 10
+    # `score` is a weight-normalised value in [0, 1] (weights sum to 1.0).
+    # A typical decent day sits around 0.70-0.80, so map the realistic
+    # 0.50-0.85 band onto 0-10 instead of the old 0.50-0.90 band, which
+    # combined with the best-3h-window daily score pinned almost every day at 10.
+    stretched = (score - 0.5) / (0.85 - 0.5) * 10
     return max(0, min(10, round(stretched)))
 
 
@@ -52,6 +56,12 @@ def get_profile_weights(body_type: str) -> dict:
             "solunar": 0.08,
             "moon": 0.07,
         })
+
+    # Normalise so the weights always sum to 1.0. Without this the per-body
+    # overrides above add to the base weights (e.g. "pond" summed to 1.2),
+    # inflating the raw score and pushing it past the top of the scale.
+    total = sum(weights.values())
+    weights = {k: v / total for k, v in weights.items()}
 
     return weights
 
@@ -159,8 +169,14 @@ async def get_fish_score_forecast(
                 best_avg = avg
                 best_window = (f"{scores[i][0]:02}:00", f"{scores[i+2][0]:02}:00")
 
+        # Daily score is the average of all hourly scores, not the best 3-hour
+        # window. The best window is still reported separately as "best_window".
+        # Using the best window as the daily score pinned nearly every day at
+        # the maximum, because dawn/dusk hours almost always score ~1.0.
+        day_mean = sum(s for _, s in scores) / len(scores) if scores else 0
+
         forecast[date_str] = {
-            "score": scale_score(best_avg),
+            "score": scale_score(day_mean),
             "best_window": f"{best_window[0]} – {best_window[1]}"
         }
         


### PR DESCRIPTION
Every sensor reported score 10 for every fish, location and day. Three compounding causes:

1. Daily score used the best 3-hour rolling window, not the day overall. Dawn/dusk hours score ~1.0 on twilight, so the best window is almost always excellent and the whole day is rated by its three best hours.
2. get_profile_weights() overrides added to the base weights instead of replacing them, so e.g. "pond" summed to 1.2 instead of 1.0, inflating the raw score.
3. scale_score() mapped the 0.50-0.90 band onto 0-10, so with (1) and (2) the value almost always clamped to 10.

Fix:
- Normalise weights so they always sum to 1.0.
- Use the mean of all hourly scores as the daily score; best_window is unchanged and still reported separately.
- Rescale to the realistic 0.50-0.85 band.

Result (Stavropol, pond, real Open-Meteo data): before 10 10 10 10 10 10 10, after 7 7 8 8 7 7 6, and it drops further on poor-pressure/rainy days.